### PR TITLE
Allow for explicit lists of paths to be provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,15 +138,17 @@ const requireFalafel = new RequireFalafel(
 
 typeOfReplacement should be one of:
 
-- `RequireFalafel.INCLUDE_NO_NODE_MODULES`, the most conservative, will
-  transform `./` and `../` imports, but will not transform any npm modules in
-  node_modules folders. Only available in node v11+.
+- `['/absolute/paths/to/files.js', require.resolve('module-names')]` will
+  transform only the absolute paths specified in an array. Use
+  `require.resolve` to get the absolute paths of libraries.
+- `RequireFalafel.INCLUDE_NO_NODE_MODULES`, will transform `./` and `../`
+  imports, but will not transform any npm modules in node_modules folders.
+  Only available in node v11+.
 - `RequireFalafel.INCLUDE_FIRST_LEVEL_NODE_MODULES` same as above, but will
   transform only the top level of node_modules that are imported from `./` or
   `../` code. Only available in node v11+.
 - `RequireFalafel.INCLUDE_NODE_MODULES` the most liberal, will
   transform all require calls, even those inside node_modules
-
 
 ### `requireFalafel.applyForBlock(block)`
 

--- a/lib.js
+++ b/lib.js
@@ -23,14 +23,14 @@ function RequireFalafel(typeOfReplacement, transformer) {
     let shouldSwap = false;
     if (typeOfReplacement == RequireFalafel.INCLUDE_NO_NODE_MODULES) {
       shouldSwap = !isNodeModule(path);
-    }
-
-    if (typeOfReplacement == RequireFalafel.INCLUDE_FIRST_LEVEL_NODE_MODULES) {
+    } else if (typeOfReplacement == RequireFalafel.INCLUDE_FIRST_LEVEL_NODE_MODULES) {
       shouldSwap = !isNodeModule(this.parent.path);
-    }
-
-    if (typeOfReplacement == RequireFalafel.INCLUDE_NODE_MODULES) {
+    } else if (typeOfReplacement == RequireFalafel.INCLUDE_NODE_MODULES) {
       shouldSwap = true;
+    } else if (typeof typeOfReplacement.indexOf == "function") {
+      shouldSwap = typeOfReplacement.indexOf(path) != -1;
+    } else {
+      throw new Error("new RequireFalafel(type, transform) called with unexpected type parameter");
     }
 
     if (shouldSwap) {

--- a/test/lib.js
+++ b/test/lib.js
@@ -95,6 +95,22 @@ describe("Require-Falafel", function() {
     });
   });
 
+  it("should replace matching paths", function() {
+    const transformation = makeUserAgentReplacer([require.resolve("./fake_node_modules/lib-7.js")]);
+    transformation.applyForBlock(function() {
+      const lib7 = require("./fake_node_modules/lib-7.js");
+      assert.equal("github.com/ojj11/require-falafel", lib7.userAgent);
+    });
+  });
+
+  it("should not replace non-matching paths", function() {
+    const transformation = makeUserAgentReplacer(['']);
+    transformation.applyForBlock(function() {
+      const lib7 = require("./fake_node_modules/lib-7.js");
+      assert.equal("lib-7", lib7.userAgent);
+    });
+  });
+
   it("should work for inline code", function() {
     const transformation = makeUserAgentReplacer(RequireFalafel.INCLUDE_NODE_MODULES);
 
@@ -134,7 +150,28 @@ describe("Require-Falafel", function() {
       });
       assert.fail("unreachable");
     } catch (e) {
-      assert.equal("Unexpected token", e.message.slice(0, 16))
+      assert.equal("Unexpected token", e.message.slice(0, 16));
+    }
+  });
+
+  it("should throw when invalid typeOfReplacement given", function() {
+    try {
+      const transformation = new RequireFalafel(
+        17,
+        function (node) {
+          if (node.type == "Literal" && node.value == "lib-7") {
+            node.update("invalid ~ javascript");
+          }
+        });
+      transformation.applyForBlock(function() {
+        require("./fake_node_modules/lib-7.js");
+      });
+      assert.fail("unreachable");
+    } catch (e) {
+      assert.equal(
+        "new RequireFalafel(type, transform) called with unexpected type parameter",
+        e.message
+      );
     }
   });
 


### PR DESCRIPTION
Allow explicit paths to be provided for the `typeOfReplacement` parameter.